### PR TITLE
Grave

### DIFF
--- a/lobby.py
+++ b/lobby.py
@@ -401,27 +401,13 @@ class Finished(State):
         self.lobby.state.start_game(player, lobby_settings, setups, punchlines)
 
 
-class Grave:
-    data: dict[str, Player]
-
-    def __init__(self, lobby: Lobby):
-        self.lobby = lobby
-
-    def bury(self, player: Player):
-        self.data[player.token] = player
-
-    def resurrect(self, player_token: str):
-        player = self.data[player_token]
-        self.lobby.add_player(self)
-
-
 class Lobby:
     uid: uuid4
     players: list[Player]
     lead: Player | None
     owner: Player
     table: list[CardOnTable]
-    grave: set
+    grave: set[Player]
     punchlines: Deck[PunchlineCard]
     setups: Deck[SetupCard]
     observer: LobbyObserver

--- a/lobby.py
+++ b/lobby.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass
 from typing import Collection, Generic, TypeVar
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
-from typing_extensions import Annotated
+from pydantic import BaseModel
 
 lobbies = {}
 
@@ -35,7 +34,6 @@ class NotAllCardsOpenedError(Exception):
 
 class UnknownPlayerError(Exception):
     pass
-
 
 
 class LobbyObserver:

--- a/main.py
+++ b/main.py
@@ -491,6 +491,7 @@ async def websocket_endpoint(
                 remove_player_tasks[player_token] = asyncio.create_task(
                     run_remove_player()
                 )
+                break
             except Exception:
                 print(f"Unexpected error: {traceback.format_exc()}")
 

--- a/main.py
+++ b/main.py
@@ -479,18 +479,20 @@ async def websocket_endpoint(
             del lobbies[lobby_token]
             print(f"Lobby deleted. lobbies={lobbies}")
 
-    try:
         while True:
-            json_data = await websocket.receive_json()
-            print(f"Received event: {json_data}")
-            await handle_event(lobby, json_data, player, cards_dao=cards_dao)
-    except WebSocketDisconnect:
-        send_messages_task.cancel()
-        lobby.disconnect(player)
-        print("before remove")
-        remove_player_tasks[player_token] = asyncio.create_task(run_remove_player())
-    except Exception:
-        print(f"Unexpected error: {traceback.format_exc()}")
+            try:
+                json_data = await websocket.receive_json()
+                print(f"Received event: {json_data}")
+                await handle_event(lobby, json_data, player, cards_dao=cards_dao)
+            except WebSocketDisconnect:
+                send_messages_task.cancel()
+                lobby.disconnect(player)
+                print("before remove")
+                remove_player_tasks[player_token] = asyncio.create_task(
+                    run_remove_player()
+                )
+            except Exception:
+                print(f"Unexpected error: {traceback.format_exc()}")
 
 
 def is_card_picked(lobby: Lobby, card_on_table):

--- a/main.py
+++ b/main.py
@@ -29,7 +29,8 @@ from lobby import (
     PunchlineCard,
     SetupCard,
     Turns,
-    GameAlreadyStartedError, UnknownPlayerError,
+    GameAlreadyStartedError,
+    UnknownPlayerError,
 )
 
 observers: list[LobbyObserver] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,23 +59,17 @@ def observer() -> Mock:
 
 @pytest.fixture
 def egor() -> Player:
-    return Player(
-        profile=Profile(name="egor", emoji="🍎", background_color="#ff0000"),
-    )
+    return Player(profile=Profile(name="egor", emoji="🍎"), token="egor-token")
 
 
 @pytest.fixture
 def anton() -> Player:
-    return Player(
-        profile=Profile(name="anton", emoji="🍎", background_color="#ff0000"),
-    )
+    return Player(profile=Profile(name="anton", emoji="🍎"), token="anton-token")
 
 
 @pytest.fixture
 def yura() -> Player:
-    return Player(
-        profile=Profile(name="yura", emoji="🍎", background_color="#ff0000"),
-    )
+    return Player(profile=Profile(name="yura", emoji="🍎"), token="yura-token")
 
 
 @pytest.fixture
@@ -121,7 +115,7 @@ def egor_connected(
     player_mock = Mock(LobbyObserver)
     observer.attach_mock(player_mock, "egor")
     egor.observer = player_mock
-    lobby.connect(egor)
+    lobby.connect(egor.token)
 
 
 @pytest.fixture
@@ -136,7 +130,7 @@ def anton_connected(
     player_mock = Mock(LobbyObserver)
     observer.attach_mock(player_mock, "anton")
     anton.observer = player_mock
-    lobby.connect(anton)
+    lobby.connect(anton.token)
 
 
 @pytest.fixture
@@ -151,7 +145,7 @@ def yura_connected(
     player_mock = Mock(LobbyObserver)
     observer.attach_mock(player_mock, "yura")
     yura.observer = player_mock
-    lobby.connect(yura)
+    lobby.connect(yura.token)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,6 @@ def lobby(  # TODO: Переименовать в лобби егора, что�
 ) -> Lobby:
     return Lobby(
         settings=lobby_settings,
-        players=[],
         owner=egor,
         state=state_gathering,
         # TODO: state gathering determines the setups and punchlines
@@ -113,9 +112,8 @@ def egor_connected(
     egor_joined: None, lobby: Lobby, egor: Player, observer: Mock
 ) -> None:
     player_mock = Mock(LobbyObserver)
+    lobby.connect(egor.token, player_mock)
     observer.attach_mock(player_mock, "egor")
-    egor.observer = player_mock
-    lobby.connect(egor.token)
 
 
 @pytest.fixture
@@ -128,9 +126,8 @@ def anton_connected(
     anton_joined: None, lobby: Lobby, anton: Player, observer: Mock
 ) -> None:
     player_mock = Mock(LobbyObserver)
+    lobby.connect(anton.token, player_mock)
     observer.attach_mock(player_mock, "anton")
-    anton.observer = player_mock
-    lobby.connect(anton.token)
 
 
 @pytest.fixture
@@ -143,9 +140,8 @@ def yura_connected(
     yura_joined: None, lobby: Lobby, yura: Player, observer: Mock
 ) -> None:
     player_mock = Mock(LobbyObserver)
+    lobby.connect(yura.token, player_mock)
     observer.attach_mock(player_mock, "yura")
-    yura.observer = player_mock
-    lobby.connect(yura.token)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def egor_connected(
     egor_joined: None, lobby: Lobby, egor: Player, observer: Mock
 ) -> None:
     player_mock = Mock(LobbyObserver)
-    lobby.connect(egor.token, player_mock)
+    lobby.connect(egor, player_mock)
     observer.attach_mock(player_mock, "egor")
 
 
@@ -126,7 +126,7 @@ def anton_connected(
     anton_joined: None, lobby: Lobby, anton: Player, observer: Mock
 ) -> None:
     player_mock = Mock(LobbyObserver)
-    lobby.connect(anton.token, player_mock)
+    lobby.connect(anton, player_mock)
     observer.attach_mock(player_mock, "anton")
 
 
@@ -140,7 +140,7 @@ def yura_connected(
     yura_joined: None, lobby: Lobby, yura: Player, observer: Mock
 ) -> None:
     player_mock = Mock(LobbyObserver)
-    lobby.connect(yura.token, player_mock)
+    lobby.connect(yura, player_mock)
     observer.attach_mock(player_mock, "yura")
 
 

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -481,6 +481,7 @@ async def test_resurrect(
 
     expected_events = [
         call.yura.welcome(),
+        call.egor.player_joined(yura),
         call.egor.player_connected(yura),
     ]
     observer.assert_has_calls(expected_events, any_order=True)

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -465,3 +465,22 @@ async def test_owner_removed(
         call.yura.owner_changed(yura),
     ]
     observer.assert_has_calls(expected_events)
+
+
+@pytest.mark.usefixtures("yura_connected", "egor_connected", "game_started")
+async def test_resurrect(
+    lobby: Lobby, egor: Player, yura: Player, observer: Mock
+) -> None:
+    lobby.disconnect(yura)
+    assert yura in lobby.all_players
+    lobby.remove_player(yura)
+    assert yura not in lobby.all_players
+    assert yura in lobby.grave
+
+    lobby.connect(yura.token, observer.yura)
+
+    expected_events = [
+        call.yura.welcome(),
+        call.egor.player_connected(yura),
+    ]
+    observer.assert_has_calls(expected_events, any_order=True)

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -189,7 +189,7 @@ def test_player_connected(lobby: Lobby, yura: Player, observer: Mock) -> None:
     player_mock = Mock(LobbyObserver)
     observer.attach_mock(player_mock, "yura")
     yura.observer = player_mock
-    lobby.connect(yura)
+    lobby.connect(yura.token)
 
     expected_events = [
         call.egor.player_connected(yura),
@@ -468,8 +468,4 @@ async def test_owner_removed(
     observer.assert_has_calls(expected_events)
 
 
-@pytest.mark.usefixtures("egor_connected")
-async def test_bury_removed_player(lobby: Lobby, egor: Player) -> None:
-    lobby.set_disconnected(egor)
-    lobby.remove_player(egor)
-    assert egor in lobby.grave
+# TODO: Тестировать коннектор

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -188,7 +188,7 @@ def test_player_joined(lobby: Lobby, yura: Player, observer: Mock) -> None:
 def test_connect_player(lobby: Lobby, yura: Player, observer: Mock) -> None:
     player_mock = Mock(LobbyObserver)
     observer.attach_mock(player_mock, "yura")
-    lobby.connect(yura.token, player_mock)
+    lobby.connect(yura, player_mock)
 
     expected_events = [
         call.egor.player_connected(yura),
@@ -477,7 +477,7 @@ async def test_resurrect(
     assert yura not in lobby.all_players
     assert yura in lobby.grave
 
-    lobby.connect(yura.token, observer.yura)
+    lobby.connect(yura, observer.yura)
 
     expected_events = [
         call.yura.welcome(),

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -185,11 +185,10 @@ def test_player_joined(lobby: Lobby, yura: Player, observer: Mock) -> None:
 
 
 @pytest.mark.usefixtures("egor_connected", "yura_joined")
-def test_player_connected(lobby: Lobby, yura: Player, observer: Mock) -> None:
+def test_connect_player(lobby: Lobby, yura: Player, observer: Mock) -> None:
     player_mock = Mock(LobbyObserver)
     observer.attach_mock(player_mock, "yura")
-    yura.observer = player_mock
-    lobby.connect(yura.token)
+    lobby.connect(yura.token, player_mock)
 
     expected_events = [
         call.egor.player_connected(yura),
@@ -199,8 +198,8 @@ def test_player_connected(lobby: Lobby, yura: Player, observer: Mock) -> None:
 
 
 @pytest.mark.usefixtures("egor_connected", "yura_connected")
-def test_player_disconnected(lobby: Lobby, yura: Player, observer: Mock) -> None:
-    lobby.set_disconnected(yura)
+def test_disconnect_player(lobby: Lobby, yura: Player, observer: Mock) -> None:
+    lobby.disconnect(yura)
 
     expected_events = [
         call.egor.player_disconnected(yura),
@@ -458,7 +457,7 @@ async def test_owner_removed(
     yura: Player,
     observer: Mock,
 ) -> None:
-    lobby.set_disconnected(egor)
+    lobby.disconnect(egor)
     assert lobby.owner is egor
     lobby.remove_player(egor)
     assert lobby.owner is yura
@@ -466,6 +465,3 @@ async def test_owner_removed(
         call.yura.owner_changed(yura),
     ]
     observer.assert_has_calls(expected_events)
-
-
-# TODO: Тестировать коннектор


### PR DESCRIPTION
Можно не делать `Connector`, можно оставить методы отключения-подключения на лобби. Просто передавать `Observer` в метод `Lobby.connect`. 

Чтобы это работало:
- Конструктор `RemotePlayer` не должен принимать игрока. На момент создания он будет знать про вебсокет и про лобби. 
- Игрок в `RemotePlayer` должен устанавливаться в момент подключения.

Кстати, вот момент подключения, буквально Player и RemotePlayer узнают друг о друге:
https://github.com/antonmolodykh/420cards-backend/blob/30a0fbf86398932a4140a735302b6f095c8ce97a/lobby.py#L128-L129

Теперь при подключении:
- Лобби ищет игрока. 
- Если нету, воскрешает и всех об этом оповещает. 
- Если не получилось воскресить, то ругается на токен
- Подключает игрока

При отключении:
- Лобби отключает игрока
- Запускается таймер для удаления
- По таймеру, лобби хоронит игрока и всех об этом оповещает